### PR TITLE
[TH2-5007] Reverted cradle: `5.1.1-dev` because `5.1.3-dev` can't wor…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Overview (5.2.2)
+# Overview (5.2.3)
 
 Message store (mstore) is an important th2 component responsible for storing raw messages into Cradle. Please refer to [Cradle repository] (https://github.com/th2-net/cradleapi/blob/master/README.md) for more details. This component has a pin for listening messages via MQ.
 
@@ -114,6 +114,10 @@ spec:
 
 This is a list of supported features provided by libraries.
 Please see more details about this feature via [link](https://github.com/th2-net/th2-common-j#configuration-formats).
+
+## 5.2.3
+
+* Reverted cradle: `5.1.1-dev` because `5.1.3-dev` can't work with pages where `removed` field is null.
 
 ## 5.2.2
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 ext {
-    cradleVersion = '5.1.3-dev'
+    cradleVersion = '5.1.1-dev'
     commonVersion = '5.4.1-dev'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-release_version=5.2.2
+release_version=5.2.3
 description='th2 mstore component'
 vcs_url=https://github.com/th2-net/th2-mstore


### PR DESCRIPTION
…k with pages where `removed` field is null.