### PR TITLE
Removed snapshot repository from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,11 +12,6 @@ repositories {
     mavenCentral()
 
     maven {
-        name 'Sonatype_snapshots'
-        url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-    }
-
-    maven {
         name 'Sonatype_releases'
         url 'https://s01.oss.sonatype.org/content/repositories/releases/'
     }


### PR DESCRIPTION
This change is required for master branch to avoid SNAPSHOT recommendation from dependabot